### PR TITLE
fix as_array() for has_one relationships

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -306,6 +306,11 @@ class MY_Model extends CI_Model
         {
             $data = json_decode(json_encode($data), FALSE);
         }
+        elseif($this->return_as == 'array')
+        {
+            $data = json_decode(json_encode($data), TRUE);
+        }
+
         if(isset($this->_select))
         {
             $this->_select = '*';


### PR DESCRIPTION
Fix the case of foreign key table data being retrieved as object despite using as_array() for has_one relationships
