### PR TITLE
Fix as_object() for has_many_pivot relationship

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -1259,7 +1259,12 @@ class MY_Model extends CI_Model
 
 
                 }
-                $sub_results = $subs;
+                                
+                if(isset($pivot_table)) {
+                    $sub_results = array_map(function($i) { return array_values($i); }, $subs);
+                } else {
+                    $sub_results = $subs;
+                }
 
                 foreach($local_key_values as $key => $value)
                 {


### PR DESCRIPTION
Non-sequential keys in the sub_results array turned what should have been array of objects [{},{}, ... ] into objects with numbers as property names 
{ "2":{}, "3":{}, ... } when using as_object() for has_many_pivot relationships
